### PR TITLE
fix FAQ error in Apache2 config

### DIFF
--- a/de-DE/intro/faqs.md
+++ b/de-DE/intro/faqs.md
@@ -71,8 +71,8 @@ ROOT_URL = http://git.domain.tld/
     ...
     ProxyPreserveHost On
     ProxyRequests off
-    ProxyPass / http://127.0.0.1:3000/
-    ProxyPassReverse / http://127.0.0.1:3000/
+    ProxyPass / http://127.0.0.1:3000
+    ProxyPassReverse / http://127.0.0.1:3000
 </VirtualHost>
 ```
 

--- a/en-US/intro/faqs.md
+++ b/en-US/intro/faqs.md
@@ -71,8 +71,8 @@ ROOT_URL = http://git.domain.tld/
     ...
     ProxyPreserveHost On
     ProxyRequests off
-    ProxyPass / http://127.0.0.1:3000/
-    ProxyPassReverse / http://127.0.0.1:3000/
+    ProxyPass / http://127.0.0.1:3000
+    ProxyPassReverse / http://127.0.0.1:3000
 </VirtualHost>
 ```
 

--- a/fr-FR/intro/faqs.md
+++ b/fr-FR/intro/faqs.md
@@ -71,8 +71,8 @@ ROOT_URL = http://git.domain.tld/
     ...
     ProxyPreserveHost On
     ProxyRequests off
-    ProxyPass / http://127.0.0.1:3000/
-    ProxyPassReverse / http://127.0.0.1:3000/
+    ProxyPass / http://127.0.0.1:3000
+    ProxyPassReverse / http://127.0.0.1:3000
 </VirtualHost>
 ```
 

--- a/zh-CN/intro/faqs.md
+++ b/zh-CN/intro/faqs.md
@@ -66,8 +66,8 @@ client_max_body_size 50m;
                  Allow from all
         </Proxy>
 
-        ProxyPass /git http://127.0.0.1:3000/
-        ProxyPassReverse /git http://127.0.0.1:3000/
+        ProxyPass /git http://127.0.0.1:3000
+        ProxyPassReverse /git http://127.0.0.1:3000
 </VirtualHost>
 ```
 


### PR DESCRIPTION
Adding a slash will cause all pages except the home page to become 404.