### PR TITLE
Improve smoothness of installation from binary

### DIFF
--- a/en-US/installation/install_from_binary.md
+++ b/en-US/installation/install_from_binary.md
@@ -4,19 +4,22 @@ name: From binary
 
 # Install from binary
 
-**Downloads are only available for latest releases, older downloads can be found at [releases](https://github.com/gogs/gogs/releases).**
+All downloads come with support for **MySQL**, **PostgreSQL**, **MSSQL**, and **TiDB**, and support self-signed certificates (build tag `cert`).
 
-All downloads come with **MySQL**, **PostgreSQL**, **MSSQL** and **TiDB** (via MySQL protocol) support, and build **with tags `cert`**. Keep in mind that support status may be different from older releases, please follow the instructions on older Gogs instances.
-
-## Notes
-
-- `mws` means builtin Windows service support. Please use the other one if you're using NSSM.
+The Windows downloads "w/ mws" have built-in Windows service support; if you use NSSM, pick the alternative Windows download.
 
 ## How to use downloads?
 
+0. Check that [prerequisites are installed](/docs/installation)
 1. Extract the archive.
-2. `cd` into the directory just created.
-3. Execute `./gogs web` and you're done.
+2. `cd` into the directory that was just created.
+3. Execute `./gogs web`.
+
+To go further, see [Configuration and run](/docs/installation/configuration_and_run.html).
+
+## Downloads
+
+Below are links to downloads for the latest releases.  Older downloads can be found at [releases](https://github.com/gogs/gogs/releases).
 
 ### 0.11.66 @ 2018-09-16
 
@@ -26,7 +29,7 @@ All downloads come with **MySQL**, **PostgreSQL**, **MSSQL** and **TiDB** (via M
 |Linux|amd64|✅|✅|LOCAL: [ZIP](https://dl.gogs.io/0.11.66/gogs_0.11.66_linux_amd64.zip) \| [TAR.GZ](https://dl.gogs.io/0.11.66/gogs_0.11.66_linux_amd64.tar.gz) - CDN: [ZIP](https://cdn.gogs.io/0.11.66/gogs_0.11.66_linux_amd64.zip) \| [TAR.GZ](https://cdn.gogs.io/0.11.66/gogs_0.11.66_linux_amd64.tar.gz)|
 |Linux|armv5|❌|❌|LOCAL: [ZIP](https://dl.gogs.io/0.11.66/gogs_0.11.66_linux_armv5.zip) - CDN: [ZIP](https://cdn.gogs.io/0.11.66/gogs_0.11.66_linux_armv5.zip)|
 |Raspberry Pi|v2/v3 / armv6|✅|✅|LOCAL: [ZIP](https://dl.gogs.io/0.11.66/gogs_0.11.66_raspi2_armv6.zip) - CDN: [ZIP](https://cdn.gogs.io/0.11.66/gogs_0.11.66_raspi2_armv6.zip)|
-|Windows|386|✅|❌|LOCAL: [ZIP](https://dl.gogs.io/0.11.66/gogs_0.11.66_windows_386.zip) \| [ZIP w/ mws](https://dl.gogs.io/0.11.66/gogs_0.11.66_windows_386_mws.zip) - CDN: [ZIP](https://cdn.gogs.io/0.11.66/gogs_0.11.66_windows_386.zip) \| [ZIP w/mws](https://cdn.gogs.io/0.11.66/gogs_0.11.66_windows_386_mws.zip)|
+|Windows|386|✅|❌|LOCAL: [ZIP](https://dl.gogs.io/0.11.66/gogs_0.11.66_windows_386.zip) \| [ZIP w/ mws](https://dl.gogs.io/0.11.66/gogs_0.11.66_windows_386_mws.zip) - CDN: [ZIP](https://cdn.gogs.io/0.11.66/gogs_0.11.66_windows_386.zip) \| [ZIP w/ mws](https://cdn.gogs.io/0.11.66/gogs_0.11.66_windows_386_mws.zip)|
 |Windows|amd64|✅|❌|LOCAL: [ZIP](https://dl.gogs.io/0.11.66/gogs_0.11.66_windows_amd64.zip) \| [ZIP w/ mws](https://dl.gogs.io/0.11.66/gogs_0.11.66_windows_amd64_mws.zip) - CDN: [ZIP](https://cdn.gogs.io/0.11.66/gogs_0.11.66_windows_amd64.zip) \| [ZIP w/ mws](https://cdn.gogs.io/0.11.66/gogs_0.11.66_windows_amd64_mws.zip)|
 |Mac OS|amd64|✅|❌|LOCAL: [ZIP](https://dl.gogs.io/0.11.66/gogs_0.11.66_darwin_amd64.zip) - CDN: [ZIP](https://cdn.gogs.io/0.11.66/gogs_0.11.66_darwin_amd64.zip)|
 
@@ -38,7 +41,7 @@ All downloads come with **MySQL**, **PostgreSQL**, **MSSQL** and **TiDB** (via M
 |Linux|amd64|✅|✅|LOCAL: [ZIP](https://dl.gogs.io/0.11.53/gogs_0.11.53_linux_amd64.zip) \| [TAR.GZ](https://dl.gogs.io/0.11.53/gogs_0.11.53_linux_amd64.tar.gz) - CDN: [ZIP](https://cdn.gogs.io/0.11.53/gogs_0.11.53_linux_amd64.zip) \| [TAR.GZ](https://cdn.gogs.io/0.11.53/gogs_0.11.53_linux_amd64.tar.gz)|
 |Linux|armv5|❌|❌|LOCAL: [ZIP](https://dl.gogs.io/0.11.53/gogs_0.11.53_linux_armv5.zip) - CDN: [ZIP](https://cdn.gogs.io/0.11.53/gogs_0.11.53_linux_armv5.zip)|
 |Raspberry Pi|v2/v3 / armv6|✅|✅|LOCAL: [ZIP](https://dl.gogs.io/0.11.53/gogs_0.11.53_raspi2_armv6.zip) - CDN: [ZIP](https://cdn.gogs.io/0.11.53/gogs_0.11.53_raspi2_armv6.zip)|
-|Windows|386|✅|❌|LOCAL: [ZIP](https://dl.gogs.io/0.11.53/gogs_0.11.53_windows_386.zip) \| [ZIP w/ mws](https://dl.gogs.io/0.11.53/gogs_0.11.53_windows_386_mws.zip) - CDN: [ZIP](https://cdn.gogs.io/0.11.53/gogs_0.11.53_windows_386.zip) \| [ZIP w/mws](https://cdn.gogs.io/0.11.53/gogs_0.11.53_windows_386_mws.zip)|
+|Windows|386|✅|❌|LOCAL: [ZIP](https://dl.gogs.io/0.11.53/gogs_0.11.53_windows_386.zip) \| [ZIP w/ mws](https://dl.gogs.io/0.11.53/gogs_0.11.53_windows_386_mws.zip) - CDN: [ZIP](https://cdn.gogs.io/0.11.53/gogs_0.11.53_windows_386.zip) \| [ZIP w/ mws](https://cdn.gogs.io/0.11.53/gogs_0.11.53_windows_386_mws.zip)|
 |Windows|amd64|✅|❌|LOCAL: [ZIP](https://dl.gogs.io/0.11.53/gogs_0.11.53_windows_amd64.zip) \| [ZIP w/ mws](https://dl.gogs.io/0.11.53/gogs_0.11.53_windows_amd64_mws.zip) - CDN: [ZIP](https://cdn.gogs.io/0.11.53/gogs_0.11.53_windows_amd64.zip) \| [ZIP w/ mws](https://cdn.gogs.io/0.11.53/gogs_0.11.53_windows_amd64_mws.zip)|
 |Mac OS|amd64|✅|❌|LOCAL: [ZIP](https://dl.gogs.io/0.11.53/gogs_0.11.53_darwin_amd64.zip) - CDN: [ZIP](https://cdn.gogs.io/0.11.53/gogs_0.11.53_darwin_amd64.zip)|
 
@@ -50,8 +53,7 @@ All downloads come with **MySQL**, **PostgreSQL**, **MSSQL** and **TiDB** (via M
 |Linux|amd64|✅|✅|LOCAL: [ZIP](https://dl.gogs.io/0.11.43/gogs_0.11.43_linux_amd64.zip) \| [TAR.GZ](https://dl.gogs.io/0.11.43/gogs_0.11.43_linux_amd64.tar.gz) - CDN: [ZIP](https://cdn.gogs.io/0.11.43/gogs_0.11.43_linux_amd64.zip) \| [TAR.GZ](https://cdn.gogs.io/0.11.43/gogs_0.11.43_linux_amd64.tar.gz)|
 |Linux|armv5|❌|❌|LOCAL: [ZIP](https://dl.gogs.io/0.11.43/gogs_0.11.43_linux_armv5.zip) - CDN: [ZIP](https://cdn.gogs.io/0.11.43/gogs_0.11.43_linux_armv5.zip)|
 |Raspberry Pi|v2/v3 / armv6|✅|✅|LOCAL: [ZIP](https://dl.gogs.io/0.11.43/gogs_0.11.43_raspi2_armv6.zip) - CDN: [ZIP](https://cdn.gogs.io/0.11.43/gogs_0.11.43_raspi2_armv6.zip)|
-|Windows|386|✅|❌|LOCAL: [ZIP](https://dl.gogs.io/0.11.43/gogs_0.11.43_windows_386.zip) \| [ZIP w/ mws](https://dl.gogs.io/0.11.43/gogs_0.11.43_windows_386_mws.zip) - CDN: [ZIP](https://cdn.gogs.io/0.11.43/gogs_0.11.43_windows_386.zip) \| [ZIP w/mws](https://cdn.gogs.io/0.11.43/gogs_0.11.43_windows_386_mws.zip)|
+|Windows|386|✅|❌|LOCAL: [ZIP](https://dl.gogs.io/0.11.43/gogs_0.11.43_windows_386.zip) \| [ZIP w/ mws](https://dl.gogs.io/0.11.43/gogs_0.11.43_windows_386_mws.zip) - CDN: [ZIP](https://cdn.gogs.io/0.11.43/gogs_0.11.43_windows_386.zip) \| [ZIP w/ mws](https://cdn.gogs.io/0.11.43/gogs_0.11.43_windows_386_mws.zip)|
 |Windows|amd64|✅|❌|LOCAL: [ZIP](https://dl.gogs.io/0.11.43/gogs_0.11.43_windows_amd64.zip) \| [ZIP w/ mws](https://dl.gogs.io/0.11.43/gogs_0.11.43_windows_amd64_mws.zip) - CDN: [ZIP](https://cdn.gogs.io/0.11.43/gogs_0.11.43_windows_amd64.zip) \| [ZIP w/ mws](https://cdn.gogs.io/0.11.43/gogs_0.11.43_windows_amd64_mws.zip)|
 |Mac OS|amd64|✅|❌|LOCAL: [ZIP](https://dl.gogs.io/0.11.43/gogs_0.11.43_darwin_amd64.zip) - CDN: [ZIP](https://cdn.gogs.io/0.11.43/gogs_0.11.43_darwin_amd64.zip)|
 
-See [Configuration and run](/docs/installation/configuration_and_run.html) to go further.


### PR DESCRIPTION
Hi @Unknwon , this PR makes some corrections to the "Installation from Binary" page, intended to make the first time experience even smoother.

Why? Having fought through the installation of a self-hosted GitLab in 2016, I was awestruck with the promising lightness of gogs. But then I almost almost tripped over the first sentence of the [Installation from binary](https://gogs.io/docs/installation/install_from_binary) page, which I (erroneously) read as: "the binary download _includes_ MySQL, PostgreSQL, etc.."

That sinking feeling _"Oh no, not another one packing everything and the kitchen sink!"_ turned out to be completely wrong. The opposite is true for gogs, and this PR intends to fix the issue by reorganising  the text a bit.

Many compliments on gogs! It gets everything _just right_.  