### PR TITLE
Requires Go 1.7

### DIFF
--- a/en-US/installation/install_from_source.md
+++ b/en-US/installation/install_from_source.md
@@ -8,7 +8,7 @@ name: From source
 
 ### Overall
 
-- [Go Programming Language](http://golang.org): Version >= 1.6
+- [Go Programming Language](http://golang.org): Version >= 1.7
 
 We are going to create a new user called `git` and install/setup everything under that user:
 


### PR DESCRIPTION
With Go 1.6.x:

$ go get -u github.com/gogs/gogs
. . .
package context: unrecognized import path "context" (import path does not begin with hostname)