### PR TITLE
Fix build tag name for sqlite3 in docs

### DIFF
--- a/de-DE/installation/install_from_source.md
+++ b/de-DE/installation/install_from_source.md
@@ -109,7 +109,7 @@ Einige Dinge sind nicht automatisch bei Gogs mit dabei, du musst Gogs mit den en
 
 Verfügbare Build-Tags sind:
 
-- `sqlite3`/`tidb`: SQLite3/TiDB-Datenbank-Unterstützung
+- `sqlite`/`tidb`: SQLite3/TiDB-Datenbank-Unterstützung
 - `pam`: PAM-Authentifizierungs-Support
 - `cert`: Unterstützung für selbst-signierte Zertifikate
 - `miniwinsvc`: Eingebauter Windows Service Support (alternativ NSSM nutzen um den Service zu erstellen)


### PR DESCRIPTION
The build tag name for sqlite3 support is just 'sqlite' and not 'sqlite3'.
Update the build instructions accordingly.