### PR TITLE
Add packager.io security warning and Debian 9

### DIFF
--- a/en-US/installation/install_from_packages.md
+++ b/en-US/installation/install_from_packages.md
@@ -8,7 +8,8 @@ name: From packages
 
 ### Packager.io
 
-- Currently enabled for Ubuntu 12.04 + 14.04 + 16.04, CentOS 6 + 7, and Debian 7 + 8.
+- **Outdated and insecure!**
+- Currently enabled for Ubuntu 12.04 + 14.04 + 16.04, CentOS 6 + 7, and Debian 7 + 8 + 9.
 - Current packages available from [packager.io](https://packager.io/gh/pkgr/gogs) (the custom config for packager.io is sometimes in `/etc/default/gogs`).
 
 ### Arch Linux


### PR DESCRIPTION
The latest version on packager.io is 0.11.34 (released Nov 22, 2017, built January 2019). The latest gogs release, which includes security fixes, is 0.11.86 (January 2019).
The "at your own risk" warning is good, but I don't think it's sufficient at this point - continuing to refer users to packager.io without an explicit warning when those builds are this outdated would be reckless. Removing the links would also be fine.
If anyone wants to update it, it looks like it lives at https://github.com/pkgr/gogs