### PR TITLE
Update packager.io information

### DIFF
--- a/de-DE/installation/install_from_packages.md
+++ b/de-DE/installation/install_from_packages.md
@@ -6,8 +6,8 @@ name: aus Paketquellen
 
 ### Packager.io
 
-- Aktuell für Ubuntu 12.04 und 14.04, CentOS 6/7 und Debian 7+8.
-- Aktuelle Pakete sind verfügbar von [packager.io](https://packager.io/gh/pkgr/gogs).
+- Aktuell für Ubuntu 14.04, 16.04 und 18.04, CentOS 6/7 und Debian 8/9/10.
+- Aktuelle Pakete sind verfügbar von [packager.io](https://packager.io/gh/gogs/gogs).
 - Hinweis: Die Pakete von Packager.io unterstützen derzeit nicht SQLite3, siehe [https://github.com/gogs/gogs/issues/2457](https://github.com/gogs/gogs/issues/2457).
 
 ### Arch Linux

--- a/en-US/installation/install_from_packages.md
+++ b/en-US/installation/install_from_packages.md
@@ -8,9 +8,8 @@ name: From packages
 
 ### Packager.io
 
-- **Outdated and insecure!**
-- Currently enabled for Ubuntu 12.04 + 14.04 + 16.04, CentOS 6 + 7, and Debian 7 + 8 + 9.
-- Current packages available from [packager.io](https://packager.io/gh/pkgr/gogs) (the custom config for packager.io is sometimes in `/etc/default/gogs`).
+- Currently enabled for Ubuntu 14.04, 16.04, and 18.04, CentOS 6 and 7, and Debian 8, 9, and 10.
+- Current packages available from [packager.io](https://packager.io/gh/gogs/gogs) (the custom config for packager.io is sometimes in `/etc/default/gogs`).
 
 ### Arch Linux
 

--- a/fr-FR/installation/install_from_packages.md
+++ b/fr-FR/installation/install_from_packages.md
@@ -17,10 +17,9 @@ Des informations pour l'installation et la configuration sur Arch Linux peuvent 
 
 ### Ubuntu/Debian
 
-- Actuellement disponible pour  Ubuntu 14.04/12.04 et Debian 7.
-- Paquets actuellement disponibles sur [packager.io](https://packager.io/gh/pkgr/gogs).
+- Actuellement disponible pour Ubuntu 14.04/16.04/18.04, Debian 8/9/10, et CentOS 6/7.
+- Paquets actuellement disponibles sur [packager.io](https://packager.io/gh/gogs/gogs).
 - Démo disponible en vidéo [YouTube](http://www.youtube.com/watch?v=xllP7BP_qgs&feature=youtu.be).
-- Construits par [@crohr](https://github.com/crohr)(Cyril Rohr).
 
 ### Synology spk
 

--- a/zh-CN/installation/install_from_packages.md
+++ b/zh-CN/installation/install_from_packages.md
@@ -8,8 +8,8 @@ name: 包管理安装
 
 ### Packager.io
 
-- 当前支持 Ubuntu 12.04 + 14.04、CentOS 6 + 7 和 Debian 7 + 8 版本。
-- 可以从 [packager.io](https://packager.io/gh/pkgr/gogs) 获取到相应包管理资源（该工具的自定义配置文件有时会放置在 `/etc/default/gogs`）。
+- 当前支持 Ubuntu 14.04 + 16.04 + 18.04、CentOS 6 + 7 和 Debian 8 + 9 + 10 版本。
+- 可以从 [packager.io](https://packager.io/gh/gogs/gogs) 获取到相应包管理资源（该工具的自定义配置文件有时会放置在 `/etc/default/gogs`）。
 
 ### Arch Linux
 


### PR DESCRIPTION
Since https://github.com/gogs/gogs/pull/5760, gogs/gogs is enabled in pkgr. This replaces pkgr/gogs links with gogs/gogs, and updates the supported distros.
I did the other translations too since the changes are theoretically straightforward, will revert those if you're not comfortable with that.