### PR TITLE
Add guide how to download via commandline

### DIFF
--- a/en-US/installation/download-commandline.md
+++ b/en-US/installation/download-commandline.md
@@ -1,0 +1,135 @@
+# Downloading Gogs via commandline
+
+Requirements: [curl](https://wikipedia.org/wiki/CURL), [wget](https://wikipedia.org/wiki/Wget)
+
+Simply copy & Paste the command to your terminal.
+If any errors accure please file an issue so we can fix it.
+
+* darwin_amd64.zip
+
+```bash
+curl -s https://api.github.com/repos/gogs/gogs/releases/latest \
+| grep "darwin_amd64.zip" \
+| cut -d : -f 2,3 \
+| tr -d \" \
+| wget -i -
+```
+* linux_386.tar.gz
+
+```bash
+curl -s https://api.github.com/repos/gogs/gogs/releases/latest \
+| grep "linux_386.tar.gz" \
+| cut -d : -f 2,3 \
+| tr -d \" \
+| wget -i -
+```
+
+* linux_386.zip
+
+```bash
+curl -s https://api.github.com/repos/gogs/gogs/releases/latest \
+| grep "linux_386.zip" \
+| cut -d : -f 2,3 \
+| tr -d \" \
+| wget -i -
+```
+
+* linux_amd64.tar.gz
+
+```bash
+curl -s https://api.github.com/repos/gogs/gogs/releases/latest \
+| grep "linux_amd64.tar.gz" \
+| cut -d : -f 2,3 \
+| tr -d \" \
+| wget -i -
+```
+
+* linux_amd64.zip
+
+```bash
+curl -s https://api.github.com/repos/gogs/gogs/releases/latest \
+| grep "linux_amd64.zip" \
+| cut -d : -f 2,3 \
+| tr -d \" \
+| wget -i -
+```
+
+* linux_armv5.zip
+
+```bash
+curl -s https://api.github.com/repos/gogs/gogs/releases/latest \
+| grep "linux_armv5.zip" \
+| cut -d : -f 2,3 \
+| tr -d \" \
+| wget -i -
+```
+
+* linux_armv6.zip
+
+```bash
+curl -s https://api.github.com/repos/gogs/gogs/releases/latest \
+| grep "linux_armv6.zip" \
+| cut -d : -f 2,3 \
+| tr -d \" \
+| wget -i -
+```
+
+* raspi_armv7.tar.gz
+
+```bash
+curl -s https://api.github.com/repos/gogs/gogs/releases/latest \
+| grep "raspi_armv7.tar.gz" \
+| cut -d : -f 2,3 \
+| tr -d \" \
+| wget -i -
+```
+
+* raspi_armv7.zip
+
+```bash
+curl -s https://api.github.com/repos/gogs/gogs/releases/latest \
+| grep "raspi_armv7.zip" \
+| cut -d : -f 2,3 \
+| tr -d \" \
+| wget -i -
+```
+
+* windows_386.zip
+
+```bash
+curl -s https://api.github.com/repos/gogs/gogs/releases/latest \
+| grep "windows_386.zip" \
+| cut -d : -f 2,3 \
+| tr -d \" \
+| wget -i -
+```
+
+* windows_386_mws.zip
+
+```bash
+curl -s https://api.github.com/repos/gogs/gogs/releases/latest \
+| grep "windows_386_mws.zip" \
+| cut -d : -f 2,3 \
+| tr -d \" \
+| wget -i -
+```
+
+* windows_amd64.zip
+
+```bash
+curl -s https://api.github.com/repos/gogs/gogs/releases/latest \
+| grep "windows_amd64.zip" \
+| cut -d : -f 2,3 \
+| tr -d \" \
+| wget -i -
+```
+
+* windows_amd64_mws.zip
+
+```bash
+curl -s https://api.github.com/repos/gogs/gogs/releases/latest \
+| grep "windows_amd64_mws.zip" \
+| cut -d : -f 2,3 \
+| tr -d \" \
+| wget -i -
+```

--- a/en-US/installation/install_from_binary.md
+++ b/en-US/installation/install_from_binary.md
@@ -21,6 +21,8 @@ To go further, see [Configuration and run](/docs/installation/configuration_and_
 
 Below are links to downloads for the latest releases.  Older downloads can be found at [releases](https://github.com/gogs/gogs/releases).
 
+Learn about [downloading Gogs via commandline](/docs/en-US/installation/download-commandline.md) (without GUI)
+
 ### 0.11.91 @ 2019-08-11
 
 |System|Type|SQLite|PAM|Download ([GitHub](https://github.com/gogs/gogs/releases/tag/v0.11.91))|

--- a/en-US/installation/install_from_binary.md
+++ b/en-US/installation/install_from_binary.md
@@ -21,7 +21,7 @@ To go further, see [Configuration and run](/docs/installation/configuration_and_
 
 Below are links to downloads for the latest releases.  Older downloads can be found at [releases](https://github.com/gogs/gogs/releases).
 
-Learn about [downloading Gogs via commandline](/docs/en-US/installation/download-commandline.md) (without GUI)
+Learn about [downloading Gogs via commandline](/docs/installation/download-commandline.md) (without GUI)
 
 ### 0.11.91 @ 2019-08-11
 


### PR DESCRIPTION
I added this because I was installing Gogs for my company on a non GUI server. 
It was a real pain getting it there directly.

Have a look. I think it is self explaining.

Regarding the link from the install_from_binary file I am not sure if the url is going to work for you on your server.

P.s. After a review I am happy to offer translation into German.  


