### PR TITLE
Update upgrade_from_binary.md

### DIFF
--- a/en-US/upgrade/upgrade_from_binary.md
+++ b/en-US/upgrade/upgrade_from_binary.md
@@ -30,10 +30,10 @@ Download and unzip the new binary:
 
 ```bash
 # Check for the latest release to download based on the OS and ARCH you are running
-$ wget https://dl.gogs.io/$VERSION/gogs_$VERSION_$OS_$ARCH.tar.gz
-$ tar -zxvf gogs_$VERSION_$OS_$ARCH.tar.gz
+$ wget https://dl.gogs.io/$VERSION/gogs_${VERSION}_${OS}_${ARCH}.tar.gz
+$ tar -zxvf gogs_${VERSION}_${OS}_${ARCH}.tar.gz
 $ ls
-gogs gogs_old  gogs-repositories gogs_$VERSION_$OS_$ARCH.tar.gz
+gogs gogs_old  gogs-repositories gogs_${VERSION}_${OS}_${ARCH}.tar.gz
 ```
 
 Copy `custom`, `data`, and `log` directories to the unzipped directory:


### PR DESCRIPTION
make bash example code usable as intended

without this, the variable names interpreted by bash are actually `$VERSION_` and `$OS_`, which are most likely unset. 