### PR TITLE
Update documentation on db password

### DIFF
--- a/de-DE/installation/configuration_and_run.md
+++ b/de-DE/installation/configuration_and_run.md
@@ -14,14 +14,14 @@ Die Standard-Konfiguration ist in `conf/app.ini` gespeichert. Du brauchst diese 
 
 Wie macht man nun eigene Änderungen, wenn man die `conf/app.ini` nicht verändern darf? Erstelle einfach eine `custom/conf/app.ini`! Die entsprechenden Schlüssel in den entsprechenden Sektionen werden die Werte aus `conf/app.ini` überschreiben.
 
-Zum Beispiel kann man, um denn Wurzelpfad, in dem die Repository-Rohdaten gespeichert werden, zu verändern, eine Zeile wie die folgende hinzufügen:
+Zum Beispiel kann man, um den Wurzelpfad, in dem die Repository-Rohdaten gespeichert werden, zu verändern, eine Zeile wie die folgende hinzufügen:
 
 ```
 [repository]
 ROOT = /home/jiahuachen/gogs-repositories
 ```
 
-Natürlich kann man auch die Datenbank-Einstellungen ändern
+Natürlich kann man auch die Datenbankeinstellungen ändern
 
 ```
 [database]
@@ -32,14 +32,14 @@ PASSWORD = root
 
 Ja, warum nicht einfach `conf/app.ini` verändern? Der Grund ist, die eigene Konfiguration sicher zu speichern:
 
-- Alle, die das Programm aus der Binärdateien installieren, können jedes mal, wenn eine neue Version rauskommt, die Dateien einfach in den Ordner kopieren, ohne etwas neu konfigurieren zu müssen.
+- Alle, die das Programm aus der Binärdateien installieren, können jedes Mal, wenn eine neue Version rauskommt, die Dateien einfach in den Ordner kopieren, ohne etwas neu konfigurieren zu müssen.
 - Für alle, die das Programm aus den Quelldateien installieren, haben wir die `custom/conf/app.ini` in der `.gitignore` aus der Versionskontrolle ausgenommen, sodass es keine neue Version erzeugt, wenn man Konfigurationsänderungen macht oder eine neue Version herunterlädt.
 
 ## Gogs Server starten
 
 ### Für Entwickler
 
-- Setze den Schlüssel `security -> INSTALL_LOCK` auf `true` in der `custom/conf/app.ini` um Gogs aus den Quelldateien zu starten
+- Setze den Schlüssel `security -> INSTALL_LOCK` auf `true` in der `custom/conf/app.ini`, um Gogs aus den Quelldateien zu starten
 - Du kannst Live-Compiling anschalten mit `bra run` im Gogs Quell-Ordner
 	- Installation von [bra](https://github.com/Unknwon/bra): ` go get -u github.com/Unknwon/bra`
 
@@ -50,4 +50,4 @@ Ja, warum nicht einfach `conf/app.ini` verändern? Der Grund ist, die eigene Kon
 - Es gibt einige Wege, Gogs zu starten:
 	- Einfach: Nutze einfach `./gogs web`
 	- Daemons: siehe [scripts](https://github.com/gogs/gogs/tree/main/scripts) Ordner
-- gucke in `/install` um die erste Konfiguration zu erstellen.
+- Sieh in `/install` nach, um die erste Konfiguration zu erstellen.

--- a/de-DE/installation/configuration_and_run.md
+++ b/de-DE/installation/configuration_and_run.md
@@ -25,7 +25,7 @@ Natürlich kann man auch die Datenbank-Einstellungen ändern
 
 ```
 [database]
-PASSWD = root
+PASSWORD = root
 ```
 
 ### Warum tun wir das?

--- a/fr-FR/installation/configuration_and_run.md
+++ b/fr-FR/installation/configuration_and_run.md
@@ -26,7 +26,7 @@ Vous pouvez également changer le mot de passe de la base de données comme ceci
 
 ```
 [database]
-PASSWD = root
+PASSWORD = root
 ```
 
 ### Pourquoi faisons-nous ça ?


### PR DESCRIPTION
The example in the French and German documentation now uses PASSWORD instead of PASSWD. Minor spelling corrections were applied to the German docs.