### PR TITLE
allow deny is depreciated since apache24

### DIFF
--- a/de-DE/intro/faqs.md
+++ b/de-DE/intro/faqs.md
@@ -91,8 +91,8 @@ ROOT_URL = http://domain.tld/git
 <VirtualHost *:80>
     ...
     <Proxy *>
-         Order allow,deny
-         Allow from all
+         Require all denied
+         Require ip 10.0.0.0/24 192.168.0.0/24 ...
     </Proxy>
 
     ProxyPass /git http://127.0.0.1:3000


### PR DESCRIPTION
The whole authorization scheme has been refactored in Apache 2.4 with RequireAll, RequireAny and RequireNone directives.