### PR TITLE
Require Go 1.20

### DIFF
--- a/de-DE/installation/install_from_source.md
+++ b/de-DE/installation/install_from_source.md
@@ -8,7 +8,7 @@ name: aus Quelldateien
 
 ### Allgemein
 
-- [Go Programming Language](http://golang.org): Version >= 1.18
+- [Go Programming Language](http://golang.org): Version >= 1.20
 
 Wir erstellen einen neuen Benutzer mit dem Namen `git` und installieren alles unter diesem Benutzer:
 
@@ -25,6 +25,7 @@ Wenn dich interessiert, welche Drittanbieter-Pakete wir benutzen, schaue dir das
 Wenn Go auf deinem System schon den Anforderungen entspricht, überspringe diesen Abschnitt.
 
 ### Download
+
 Die aktuellen Versionen für dein Betriebssystem findest du auf der offiziellen Seite [golang.org](https://golang.org/dl/)
 
 Installiere Go in `/home/git/local/go`, sodass es keine Konflikte mit zukünftigen Updates des Paketmanagers gibt:

--- a/en-US/installation/install_from_source.md
+++ b/en-US/installation/install_from_source.md
@@ -6,7 +6,7 @@ name: From source
 
 ## Installing Go
 
-Gogs requires Go 1.18 to compile, please refer to the [official documentation](https://golang.org/doc/install) for how to install Go in your system.
+Gogs requires Go 1.20 to compile, please refer to the [official documentation](https://golang.org/doc/install) for how to install Go in your system.
 
 ## Set Up the Environment
 

--- a/fr-FR/installation/install_from_source.md
+++ b/fr-FR/installation/install_from_source.md
@@ -8,7 +8,7 @@ name: A partir des sources
 
 ### Global
 
-- [Go Programming Language](http://golang.org): Version >= 1.18
+- [Go Programming Language](http://golang.org): Version >= 1.20
 
 Nous allons créer un nouvel utilisateur appelé `git` et installer / configurer tout sous cet utilisateur:
 

--- a/zh-CN/installation/install_from_source.md
+++ b/zh-CN/installation/install_from_source.md
@@ -6,7 +6,7 @@ name: 源码安装
 
 ## 安装 Go 语言
 
-Gogs 要求至少使用 Go 1.18 或更高的版本进行编译，具体安装步骤请参考 [官方文档](https://golang.org/doc/install)。
+Gogs 要求至少使用 Go 1.20 或更高的版本进行编译，具体安装步骤请参考 [官方文档](https://golang.org/doc/install)。
 
 ## 设置环境
 


### PR DESCRIPTION
https://github.com/gogs/gogs/commit/4821e8978033ea2321720d5356b7cbe12cf6dd3d upgraded a dependency which now uses errors.Join, a function introduced in go1.20 . This is now the minimum supported version to build gogs from source.