### PR TITLE
Update install_from_binary.md

### DIFF
--- a/zh-CN/installation/install_from_binary.md
+++ b/zh-CN/installation/install_from_binary.md
@@ -15,7 +15,7 @@ name: 二进制安装
 0. 检查[环境要求](/docs/installation)是否已满足
 1. 解压压缩包。
 2. 使用命令 `cd` 进入到刚刚创建的目录。
-3. 执行命令 `./gogs web`。
+3. 执行命令 `.\gogs web`。
 4. Gogs 默认会在端口 `3000` 启动 HTTP 服务，访问 `/install` 以进行初始配置（例如 http://localhost:3000/install ）。
 
 安装完成后可继续参照 [配置与运行](configuration_and_run.html)。


### PR DESCRIPTION
In [how to use downloads](https://gogs.io/docs/installation/install_from_binary#how-to-use-downloads%3F) section of the document
```./gogs web'``` cannot run normally under cmd, if modified to ```.\gogs web```, running normally in both powershell and cmd
![image](https://github.com/gogs/docs/assets/22126367/b77fcd0f-8f89-4203-88d3-08567493bd04)
![image](https://github.com/gogs/docs/assets/22126367/b0be11a3-1b72-4357-bc3d-58123fcf740b)
