### PR TITLE
* mailer > email, service > auth

### DIFF
--- a/en-US/advanced/configuration_cheat_sheet.md
+++ b/en-US/advanced/configuration_cheat_sheet.md
@@ -138,7 +138,7 @@ Name|Description
 `COOKIE_REMEMBER_NAME`|Name of cookie that saves auto-login information.
 `REVERSE_PROXY_AUTHENTICATION_USER`|Header name for reverse proxy authentication username.
 
-### Service (`service`)
+### Auth (`auth`)
 
 Name|Description
 ----|-----------
@@ -165,7 +165,7 @@ Name|Description
 `SKIP_TLS_VERIFY`|Indicate whether to allow insecure certification or not.
 `PAGING_NUM`|Number of webhook history that are shown in one page.
 
-### Mailer (`mailer`)
+### Email (`email`)
 
 Name|Description
 ----|-----------


### PR DESCRIPTION
based on CHANGELOG.md

./CHANGELOG.md:50:- Configuration section `[mailer]` is no longer used, please use `[email]`. ./CHANGELOG.md:190:- Configuration section `[mailer]` is deprecated and will end support in 0.13.0, please start using `[email]`.