### PR TITLE
[fix] incorrect document for mailer

### DIFF
--- a/de-DE/advanced/configuration_cheat_sheet.md
+++ b/de-DE/advanced/configuration_cheat_sheet.md
@@ -104,7 +104,7 @@ Jede Konfiguration, die mit :exclamation: markiert ist, solltest du auf dem Stan
 - `SKIP_TLS_VERIFY`: Entscheidet ob unsichere Zertifikate erlaubt sind oder nicht.
 - `PAGING_NUM`: Anzahl der Webhook-Historie, die auf einer Seite angezeigt wird.
 
-## Mailer (`mailer`)
+## Mailer (`email`)
 
 - `ENABLED`: Aktivieren, um den Mail-Service zu benutzen.
 - `DISABLE_HELO`: HELO-Operation ausschalten.
@@ -112,7 +112,7 @@ Jede Konfiguration, die mit :exclamation: markiert ist, solltest du auf dem Stan
 - `HOST`: SMTP Server-Adresse und -Port (Beispiel: smtp.gogs.io:587).
 - `FROM`: Absender-Adresse, RFC 5322. Es kann eine einfache Adresse sein oder das "Name" <email@example.com> Format.
 - `USER`: Benutzername für den Mailer (Normalerweise deine e-Mail-Adresse).
-- `PASSWD`: Passwort für den Mailer.
+- `PASSWORD`: Passwort für den Mailer.
 - `SKIP_VERIFY`: Selbstsignierte Zertifikate nicht überprüfen.
 
 Hinweis: Gogs unterstützt nur SMTP mit STARTTLS.

--- a/en-US/advanced/configuration_cheat_sheet.md
+++ b/en-US/advanced/configuration_cheat_sheet.md
@@ -165,7 +165,7 @@ Name|Description
 `SKIP_TLS_VERIFY`|Indicate whether to allow insecure certification or not.
 `PAGING_NUM`|Number of webhook history that are shown in one page.
 
-### Mailer (`mailer`)
+### Mailer (`email`)
 
 Name|Description
 ----|-----------
@@ -177,7 +177,7 @@ Name|Description
 `SKIP_VERIFY`|Do not verify the self-signed certificates.
 `FROM`|Mail from address, RFC 5322. This can be just an email address, or the `"Name" <email@example.com>` format.
 `USER`|Username of mailer (usually just your e-mail address).
-`PASSWD`|Password of mailer.
+`PASSWORD`|Password of mailer.
 `USE_PLAIN_TEXT`|Indicate whether to use `text/plain` as format of content or not.
 
 Note: Gogs supports only SMTP with STARTTLS.

--- a/fr-FR/advanced/configuration_cheat_sheet.md
+++ b/fr-FR/advanced/configuration_cheat_sheet.md
@@ -95,7 +95,7 @@ Nom |Description
 `SKIP_TLS_VERIFY`|Indique si un certificat non-sécurisé est autorisé ou pas.
 `PAGING_NUM`|Nombre de webhook affiché sur une page d'historique.
 
-## Serveur de messagerie ( `mailer` )
+## Serveur de messagerie ( `email` )
 
 Nom |Description
 ----|-----------
@@ -105,7 +105,7 @@ Nom |Description
 `HOST`|Adresse email du serveur SMTP.
 `FROM`|Adresse email, la RFC 5322. Cela peut être juste une adresse e-mail, ou une chaîne du type `"Nom" <email@example.com>`.
 `USER`|Nom d'utilisateur pour le serveur de messagerie (habituellement juste votre adresse e-mail).
-`PASSWD`|Mot de passe pour le serveur de messagerie.
+`PASSWORD`|Mot de passe pour le serveur de messagerie.
 `SKIP_VERIFY`|Ne pas vérifier les certificats auto-signés.
 
 ## OAuth

--- a/zh-CN/advanced/configuration_cheat_sheet.md
+++ b/zh-CN/advanced/configuration_cheat_sheet.md
@@ -165,7 +165,7 @@ name: 配置文件手册
 `SKIP_TLS_VERIFY`|指示是否允许向具有非信任证书的地址发送通知
 `PAGING_NUM`|Web 钩子历史页面每页显示记录条数
 
-### 邮件 (`mailer`)
+### 邮件 (`email`)
 
 名称|描述
 ----|----
@@ -177,7 +177,7 @@ name: 配置文件手册
 `SKIP_VERIFY`|不验证自签发证书的有效性
 `FROM`|邮箱的来自地址，遵循 RFC 5322规范，可以是一个单纯的邮箱地址或者 `"名字" <email@example.com>` 的形式
 `USER`|邮箱用户名
-`PASSWD`|邮箱密码
+`PASSWORD`|邮箱密码
 `USE_PLAIN_TEXT`|使用 `text/plain` 作为邮件内容格式
 
 备注：Gogs 仅支持使用 STARTTLS 的 SMTP 协议


### PR DESCRIPTION
Fix the incorrect document by replacing the deprecated mailer keyword with email.